### PR TITLE
Change version API GITLAB to get Projects

### DIFF
--- a/src/Origins/GitLab.js
+++ b/src/Origins/GitLab.js
@@ -43,7 +43,7 @@ class GitLab extends React.Component {
   }
 
   async componentDidMount() {
-    const resp = await this.fetch(`https://gitlab.com/api/v3/projects`);
+    const resp = await this.fetch(`https://gitlab.com/api/v4/projects`);
     const projects = await resp.json();
     if (projects.message) {
         this.setState ({


### PR DESCRIPTION
Request: https://gitlab.com/api/v3/projects
Response: {"error":"API V3 is no longer supported. Use API V4 instead."}